### PR TITLE
minimum viable pyproject.toml to make poetry install-able

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]


### PR DESCRIPTION
- pyproject.toml specifies minimum requirements necessary to build wheel
- still use setup.py for build